### PR TITLE
【重构】更合理地内联C代码、支持函数隐式结束、以及修复Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /build
 /.vscode
+/.xmake
+/test/*.exe
+/test/*.c
+/test/*.obj

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
-project(HercodeCompiler C)
+project(HerCode_Compiler C)
+
+if (MSVC)
+    add_compile_options(/WX- /wd4090)
+endif()
 
 # 设置C标准
 set(CMAKE_C_STANDARD 11)
@@ -11,6 +15,10 @@ file(GLOB_RECURSE SOURCES "src/*.c")
 
 # 生成可执行文件
 add_executable(hercode_compiler ${SOURCES})
-add_compile_options(-Wall -Werror -Wstrict-prototypes -Wmissing-prototypes -O2 -Os)
+if (MSVC)
+    add_compile_options(/W4 /WX)
+else()
+    add_compile_options(-Wall -Werror -Wstrict-prototypes -Wmissing-prototypes -O2 -Os)
+endif()
 
 install(TARGETS hercode_compiler DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -1,60 +1,155 @@
-# Hercode Compiler 
-能想出来写这个的，家里请啥都没用了吧
+# 🎀 HerCode Compiler: 编译你的专属代码世界! ✨
 
-感觉太适合拿来当成编译作业了 
+欢迎来到 HerCode 的世界！🎉 HerCode 是一款专为编程初学者（特别是女孩子们💖）设计的、简洁易懂的编程语言。<br>
+它的目标是让你像写日记一样自然地表达创意，体验编程的乐趣与魅力。本项目是 HerCode 语言的编译器，使用 C 语言编写。
 
-拿C语言写的，就这样 
+(P.S. 能想出来写这个的，家里请啥都没用了吧。。。感觉太适合拿来当成编译原理的作业了😉)
 
-HerCode语法：
-```
-Hello! Her World
+## 🌟 特性
+
+* ✨ **简洁语法**: 像说话一样写代码，上手轻松。
+* 🗣️ **友好输出**: 使用 `say` 关键字，轻松打印信息。
+* 🔄 **C代码兼容**: 无缝嵌入C代码片段，扩展无限可能！
+* 🛠️ **易于构建**: 支持 CMake 和 xmake 构建系统。
+
+## 🚀 HerCode 快速上手
+
+HerCode 的语法非常简单，让我们来看一个例子：
+
+```hercode
+# 这是一个 HerCode 程序示例
+
+# 定义一个函数，打印欢迎信息
 function say_hello:
-	say "Hello! Her World" #注释
-	say "编程很美,也属于你" #注释2
+	say "你好，欢迎来到 HerCode 的编程花园！🌷" #注释
+	say "编程很美，也属于你。✨" #注释2
 end
+
+# 程序主入口
 start:
-	say_hello
+    say_hello # 调用上面定义的函数
 end
 ```
 
-编译器使用：
-```
-./hercode_compiler.exe her.hercode hercode.exe
-```
-第一个参数是hercode的代码，第二个是输出文件
+**基本语法元素:**
 
+* `function <名称>:` : 定义一个函数。
+* `end` : 结束一个函数定义结束 **（现已支持隐式结束）**。
+* `say "内容"` : 打印一行文字到控制台。
+* `start:` : 标志着程序执行的起点。
+* `#` : HerCode 中的单行注释。
 
-## 20250531更新
+## ⚙️ 编译器使用方法
 
-一个trick,可以和C代码兼容，我暴力的把所有标准库头文件都给扔到输出的C文件上
+1. 编写你的 HerCode 代码，并保存为 `.hercode` 文件 (例如 `her.hercode`)。
+2. 打开终端，使用以下命令编译：
+    ```bash
+    ./hercode_compiler.exe her.hercode --out=my_program.exe -r
+    ```
+    * 第一个参数：你的 HerCode 源文件。
+    * 第二个参数：你希望生成的可执行文件的名称（可选，默认生成hercode.exe）。
+	* 第三个参数：是否清除临时文件，-r表清除（可选）。  
+3. 运行生成的可执行文件：
+    ```bash
+    ./my_program.exe
+    ```
 
-```
-time_t rawtime;
-struct tm *info;
-#define BST (+1)
-#define CCT (+8)
-time(&rawtime);
-/* 获取 GMT 时间 */
-info = gmtime(&rawtime );
+## 🧩 嵌入C代码指南
 
-printf("当前的世界时钟：\n");
-printf("伦敦：%2d:%02d\n", (info->tm_hour+BST)%24, info->tm_min);
-printf("中国：%2d:%02d\n", (info->tm_hour+CCT)%24, info->tm_min);
+HerCode 编译器支持直接在 `.hercode` 文件中嵌入C语言代码！
 
-Hello! Her World
-#「你可以做到(you_can_do_this)
-#这是一段“鼓励式函数”：
-#-功能：向终端打印两句话，欢迎女孩们来到专属的编程世界
-#－关键字说明：
-#function 定义函数（像在写日记那样自然）
-#say 输出一句温暖的话
-# end 结束函数或代码块
-function you_can_do_this:
-	say "Hello Her World"
-	say "看啥？Python不比这好用？"
-end
+* 在你的 `.hercode` 文件中，所有位于 `__c__ { ... }` 特殊标识 **内** 的内容都会被当作C代码。
+* 这部分C代码的注释请使用C语言风格的 `//`。
+* `__c__ { ... }` 特殊标识 **外** 的内容则必须遵循 HerCode 语法，注释使用 `#`。
+* 编译器会自动包含常用的C标准库头文件，方便你直接调用C函数。
+
+**示例 (`inline_c.hercode`):**
+
+```hercode
+# inline.hercode
+
+function inline:
+    say "HerCode调用C代码："
+    __c__ {
+        time_t rawtime;
+        struct tm *info;
+        #define BST (+1)
+        #define CCT (+8)
+        time(&rawtime);
+        /* 获取 GMT 时间 */
+        info = gmtime(&rawtime );
+
+        printf("\t当前的世界时钟：\n");
+        printf("\t中国时间 %2d:%02d\n", (info->tm_hour+CCT)%24, info->tm_min);
+        printf("\t伦敦时间 %2d:%02d\n", (info->tm_hour+BST)%24, info->tm_min);
+    }
+    say "inline函数结束"
+
+function add:
+    say "HerCode准备执行C加法"
+    __c__ {
+        int x = 7, y = 8;
+        printf("\tx + y = %d\n", x + y);
+    }
+    say "add函数结束"
+
+function main:
+    say "HerCode进入main"
+
+    __c__ {
+        // 可以直接写C代码
+        printf("\n");
+        printf("Hello! Her World\n");
+        printf("编程很美，也属于你\n");
+    }
+
+    say " "
+    inline
+    add
+    say " "
+    
+    say "main函数结束"
+	# 不会报错，因为现已支持函数定义隐式结束。
+
 start:
-	you_can_do_this
+    main
 end
 ```
-在Hello! Her World之前，代码都是C代码，直接放到main函数下，注释和C语言一样用//，在这之后就得是HerCode的写法了，注释就必须得用#
+
+## 🛠️ 如何构建编译器
+
+你的项目包含 `CMakeLists.txt` 和 `xmake.lua`，这意味着你可以使用 CMake 或 xmake 来构建 HerCode 编译器：
+
+### 使用 CMake
+
+1. 创建并进入一个构建目录：
+    ```bash
+    mkdir build
+    cd build
+    ```
+2. 运行 CMake 生成构建文件：
+    ```bash
+    cmake ..
+    ```
+3. 编译项目：
+    ```bash
+    cmake --build .
+    # 或者在支持的平台上使用 make, ninja 等
+    ```
+
+### 使用 xmake
+
+1. 在项目根目录下直接运行：
+    ```bash
+    xmake
+    ```
+2. 如果需要重新构建或清理：
+    ```bash
+    xmake rebuild
+    xmake clean
+    ```
+
+## 💖 结语
+
+希望你喜欢 HerCode！编码愉快，愿你的代码像诗一样优美！✍️<br>
+如果你有任何想法、建议，或者发现了什么好玩/奇怪的 "特性" 😉，欢迎提出 Issue 或参与贡献！

--- a/include/ast.h
+++ b/include/ast.h
@@ -6,21 +6,24 @@ typedef enum
     STMT_SAY,
     STMT_FUNCTION_DEF,  // 函数定义
     STMT_FUNCTION_CALL, // 函数调用
+    STMT_C_BLOCK,       // 内嵌C代码块
+    AST_C_BLOCK         // C代码块
 } NodeType;
 
 typedef struct ASTNode
 {
     NodeType type;
-    char *value; // 对于函数，存储函数名
-
-    // 函数定义的函数体
+    char *value; 
+    char *func_name;
     struct ASTNode **body;
     int body_count;
+    char *c_code; // 内联C代码
 } ASTNode;
 
-ASTNode *create_say_node(char *str);
+ASTNode *create_say_node(const char *value);
+ASTNode *create_c_block_node(const char *c_code);
 void free_node(ASTNode *node);
-ASTNode *create_function_call_node(char *name);
-ASTNode *create_function_def_node(char *name, ASTNode **body, int body_count);
-ASTNode *create_block_node(ASTNode **nodes, int count);
+ASTNode *create_function_call_node(const char *func_name);
+ASTNode *create_function_def_node(const char *func_name, ASTNode **body, int body_count);
+ASTNode *create_block_node(ASTNode **stmts, int count);
 #endif

--- a/include/codegen.h
+++ b/include/codegen.h
@@ -9,5 +9,5 @@ typedef struct
 
 // 最大函数数量
 FunctionDef *find_function(const char *name, FunctionDef **functions, int function_count);
-void generate_c_code(const char *c_header, ASTNode **nodes, int count, FILE *output);
+void generate_c_code(ASTNode **nodes, int count, FILE *output);
 void compile(char *c_filename, char *output_name);

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -1,10 +1,10 @@
 #ifndef LEXER_H
 #define LEXER_H
 
-typedef enum
-{
+typedef enum {
     TOKEN_EOF,
-    TOKEN_UNKNOWN,
+    TOKEN_UNKNOWN = 1,
+    TOKEN_C_BLOCK, // 支持 __c__ { ... } 内联C代码块
     TOKEN_SAY,
     TOKEN_STRING,
     TOKEN_SEMI, // 不再使用
@@ -15,7 +15,9 @@ typedef enum
     TOKEN_DEDENT,
     TOKEN_COLON,
     TOKEN_FUNCTION,  // function 关键字
-    TOKEN_IDENTIFIER // 函数名
+    TOKEN_LBRACE,    // {
+    TOKEN_RBRACE,    // }
+    TOKEN_IDENTIFIER // 普通标识符
 } TokenType;
 
 typedef struct Token

--- a/src/ast.c
+++ b/src/ast.c
@@ -2,19 +2,33 @@
 #include <stdlib.h>
 #include <string.h>
 
-ASTNode *create_say_node(char *str)
+ASTNode *create_say_node(const char *str)
 {
     ASTNode *node = malloc(sizeof(ASTNode));
     node->type = STMT_SAY;
-    node->value = strdup(str);
+    node->value = _strdup(str);
+    node->body = NULL;
+    node->body_count = 0;
+    node->c_code = NULL;
     return node;
 }
 
-ASTNode *create_function_def_node(char *name, ASTNode **body, int body_count)
+ASTNode *create_c_block_node(const char *c_code)
+{
+    ASTNode *node = malloc(sizeof(ASTNode));
+    node->type = STMT_C_BLOCK;
+    node->value = NULL;
+    node->body = NULL;
+    node->body_count = 0;
+    node->c_code = _strdup(c_code ? c_code : "");
+    return node;
+}
+
+ASTNode *create_function_def_node(const char *name, ASTNode **body, int body_count)
 {
     ASTNode *node = malloc(sizeof(ASTNode));
     node->type = STMT_FUNCTION_DEF;
-    node->value = strdup(name);
+    node->value = _strdup(name);
     node->body = malloc(sizeof(ASTNode *) * body_count);
     node->body_count = body_count;
 
@@ -26,23 +40,35 @@ ASTNode *create_function_def_node(char *name, ASTNode **body, int body_count)
     return node;
 }
 
-ASTNode *create_function_call_node(char *name)
+ASTNode *create_function_call_node(const char *func_name)
 {
     ASTNode *node = malloc(sizeof(ASTNode));
     node->type = STMT_FUNCTION_CALL;
-    node->value = strdup(name);
+    node->func_name = _strdup(func_name);
+    node->value = _strdup(func_name); // 兼容 codegen 逻辑
     node->body = NULL;
     node->body_count = 0;
+    node->c_code = NULL;
     return node;
 }
 
 void free_node(ASTNode *node)
 {
-    if (node)
+    if (!node)
+        return;
+    if (node->func_name)
+        free(node->func_name);
+    if (node->body)
     {
-        free(node->value);
-        free(node);
+        for (int i = 0; i < node->body_count; ++i)
+            free_node(node->body[i]);
+        free(node->body);
     }
+    if (node->value)
+        free(node->value);
+    if (node->c_code)
+        free(node->c_code);
+    free(node);
 }
 
 ASTNode *create_block_node(ASTNode **nodes, int count)
@@ -51,9 +77,9 @@ ASTNode *create_block_node(ASTNode **nodes, int count)
     if (!node)
         return NULL;
 
-    node->type = STMT_SAY; // 暂时使用SAY类型
+    node->type = STMT_C_BLOCK; // 或者根据实际需要设置类型
     node->value = NULL;
-    node->body = malloc(sizeof(ASTNode *) * count);
+    node->body = calloc(count, sizeof(ASTNode *));
     if (!node->body)
     {
         free(node);
@@ -66,5 +92,6 @@ ASTNode *create_block_node(ASTNode **nodes, int count)
         node->body[i] = nodes[i];
     }
 
+    node->c_code = NULL;
     return node;
 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -27,18 +27,20 @@ Token *new_token(TokenType type, const char *value)
 {
     Token *token = malloc(sizeof(Token));
     token->type = type;
-    token->value = value ? strdup(value) : NULL; // 允许NULL值
+    token->value = value ? _strdup(value) : NULL; // 允许NULL值
+    printf("[LEXER] 新建token: 类型=%d, 值=\"%s\"", type, value ? value : "NULL");
     return token;
 }
+
 Token *next_token(Lexer *lexer)
 {
-    printf("Current char: %c, pos: %d\n", lexer->current_char, lexer->pos);
+    printf("[LEXER] 当前字符: %c, 位置: %d\n", lexer->current_char, lexer->pos);
 
     // 处理待生成的DEDENT
     if (lexer->pending_dedents > 0)
     {
         lexer->pending_dedents--;
-        printf("[LEXER] Generating pending DEDENT (%d left)\n", lexer->pending_dedents);
+        printf("[LEXER] 生成待处理的DEDENT (%d个)\n", lexer->pending_dedents);
         return new_token(TOKEN_DEDENT, NULL);
     }
 
@@ -48,12 +50,12 @@ Token *next_token(Lexer *lexer)
         // 文件结束时处理剩余缩进
         if (lexer->indent_top > 0)
         {
-            printf("[LEXER] End of file, generating DEDENT for remaining indent\n");
+            printf("[LEXER] 文件结束，生成剩余缩进的DEDENT (%d个)\n", lexer->indent_top);
             lexer->indent_top--;
             lexer->pending_dedents = lexer->indent_top;
             return new_token(TOKEN_DEDENT, NULL);
         }
-        printf("[LEXER] End of file, returning EOF token\n");
+        printf("[LEXER] 文件结束，返回EOF token\n");
         return new_token(TOKEN_EOF, NULL);
     }
 
@@ -65,19 +67,25 @@ Token *next_token(Lexer *lexer)
             {
                 advance(lexer);
             }
-            printf("[LEXER] Skipped a comment\n");
+            printf("[LEXER] 跳过注释\n");
             continue; // 跳过注释后继续处理其他token
         }
         // 处理单字符分隔符
         switch (lexer->current_char)
         {
-        case ':': // 冒号
+        case ':':
             advance(lexer);
             return new_token(TOKEN_COLON, ":");
-        case ';': // 分号（如果需要）
+        case ';':
             advance(lexer);
             return new_token(TOKEN_SEMI, ";");
-        case '\n': // 换行符（已经处理，但为了完整）
+        case '{':
+            advance(lexer);
+            return new_token(TOKEN_LBRACE, "{");
+        case '}':
+            advance(lexer);
+            return new_token(TOKEN_RBRACE, "}");
+        case '\n':
             return handle_newline_and_indent(lexer);
         default:
             break;
@@ -89,7 +97,7 @@ Token *next_token(Lexer *lexer)
             continue;
         }
 
-        if (isalpha(lexer->current_char))
+        if (isalpha(lexer->current_char) || lexer->current_char == '_')
         {
             char buffer[256];
             int i = 0;
@@ -106,7 +114,33 @@ Token *next_token(Lexer *lexer)
                     advance(lexer);
             }
             buffer[i] = '\0';
-            printf("Identifier: %s\n", buffer);
+            printf("[LEXER] 标识符: %s\n", buffer);
+            if (strcmp(buffer, "__c__") == 0)
+            {
+                // 跳过空白
+                while (lexer->current_char == ' ' || lexer->current_char == '\t') advance(lexer);
+                if (lexer->current_char == '{')
+                {
+                    // 进入C代码块
+                    int brace_level = 1;
+                    advance(lexer); // 跳过第一个{
+                    int start = lexer->pos;
+                    while (lexer->current_char != '\0' && brace_level > 0)
+                    {
+                        if (lexer->current_char == '{') brace_level++;
+                        else if (lexer->current_char == '}') brace_level--;
+                        advance(lexer);
+                    }
+                    int end = lexer->pos - 1; // 不包含最后一个}
+                    int len = end - start;
+                    char* c_code = (char*)malloc(len + 1);
+                    strncpy(c_code, lexer->source + start, len);
+                    c_code[len] = '\0';
+                    return new_token(TOKEN_C_BLOCK, c_code);
+                }
+                // 如果不是 { ，作为普通标识符处理
+            }
+
             if (strcmp(buffer, "say") == 0)
                 return new_token(TOKEN_SAY, "say");
             if (strcmp(buffer, "start") == 0 && lexer->current_char == ':')
@@ -138,6 +172,7 @@ Token *next_token(Lexer *lexer)
             return new_token(TOKEN_STRING, buffer);
         }
 
+        printf("[LEXER] 未知token 在 %d 位置, 字符 = '%c'\n", lexer->pos, lexer->current_char);
         Token *unknown = new_token(TOKEN_UNKNOWN, (char[]){lexer->current_char, '\0'});
         advance(lexer);
         return unknown;
@@ -165,7 +200,7 @@ Token *handle_newline_and_indent(Lexer *lexer)
     // 检查是否到达EOF
     if (lexer->current_char == '\0')
     {
-        printf("[LEXER] End of file after newline, no token generated\n");
+        printf("[LEXER] 文件结束，不生成token\n");
         return NULL;
     }
 
@@ -180,19 +215,19 @@ Token *handle_newline_and_indent(Lexer *lexer)
         // 检查是否到达行尾或文件尾
         if (lexer->current_char == '\0')
         {
-            printf("[LEXER] End of file during indentation calculation, no token generated\n");
+            printf("[LEXER] 文件结束，不生成token\n");
             return NULL;
         }
     }
 
     // 添加调试信息
-    printf("[LEXER] Newline: new_indent=%d, current_indent_stack=%d\n",
+    printf("[LEXER] 新行: new_indent=%d, current_indent_stack=%d\n",
            new_indent, lexer->indent_stack[lexer->indent_top]);
 
     // 如果遇到连续换行符或文件结束
     if (lexer->current_char == '\n' || lexer->current_char == '\0')
     {
-        printf("[LEXER] Newline without content, returning NEWLINE token\n");
+        printf("[LEXER] 遇到换行或文件结束，返回NEWLINE token\n");
         return new_token(TOKEN_NEWLINE, NULL);
     }
 
@@ -215,14 +250,18 @@ Token *handle_newline_and_indent(Lexer *lexer)
             levels_to_dedent++;
         }
 
-        // 设置待生成的DEDENT数量
-        lexer->pending_dedents = levels_to_dedent;
-
-        // 如果还有更多DEDENT需要生成，留待后续处理
-        if (levels_to_dedent > 1)
-        {
+        // 返回一个 DEDENT 符号
+        // 设置 pending_dedents（确保不为负），next_token() 可能需要生成的额外 DEDENT
+        if (levels_to_dedent > 0) {
             lexer->pending_dedents = levels_to_dedent - 1;
+        } else {
+            // new_indent >= current_indent 或者栈为空
+            // 本应由 handle_newline_and_indent 中更早的条件捕获（安全起见设置为 0）
+            lexer->pending_dedents = 0;
         }
+        
+        printf("[LEXER] 生成DEDENT: new_indent=%d, old_current_indent=%d, levels_dedented=%d, pending_dedents_set_to=%d\n",
+               new_indent, current_indent, levels_to_dedent, lexer->pending_dedents);
 
         return new_token(TOKEN_DEDENT, NULL);
     }

--- a/src/parser.c
+++ b/src/parser.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include "ast.h"
 
 const char *token_type_to_string(TokenType type)
 {
@@ -31,6 +32,10 @@ const char *token_type_to_string(TokenType type)
         return "IDENTIFIER";
     case TOKEN_COLON:
         return "COLON";
+    case TOKEN_C_BLOCK:
+        return "C_BLOCK";
+    case TOKEN_START:
+        return "START";
     default:
         return "UNRECOGNIZED";
     }
@@ -65,215 +70,315 @@ void eat(Parser *parser, TokenType type)
 {
     if (parser->current_token->type == type)
     {
+        if (type == TOKEN_START) {
+            int pos = parser->lexer->pos;
+            size_t src_len = strlen(parser->lexer->source);
+            int left = pos - 10; if (left < 0) left = 0;
+            int right = pos + 10; if ((size_t)right > src_len) right = (int)src_len;
+            char buf[64] = {0};
+            size_t copy_len = right - left;
+            if (copy_len >= sizeof(buf)) copy_len = sizeof(buf) - 1;
+            strncpy(buf, parser->lexer->source + left, copy_len);
+            buf[copy_len] = '\0';
+            printf("[PARSER][EAT-BEFORE] TOKEN_START: lexer->pos=%d, src[周围]=\"%s\", token_type=%d (%s), value='%s'\n", pos, buf, parser->current_token->type, token_type_to_string(parser->current_token->type), parser->current_token->value ? parser->current_token->value : "NULL");
+        }
         free_token(parser->current_token);
         parser->current_token = next_token(parser->lexer);
+        if (type == TOKEN_START) {
+            int pos = parser->lexer->pos;
+            size_t src_len = strlen(parser->lexer->source);
+            int left = pos - 10; if (left < 0) left = 0;
+            int right = pos + 10; if ((size_t)right > src_len) right = (int)src_len;
+            char buf[64] = {0};
+            size_t copy_len = right - left;
+            if (copy_len >= sizeof(buf)) copy_len = sizeof(buf) - 1;
+            strncpy(buf, parser->lexer->source + left, copy_len);
+            buf[copy_len] = '\0';
+            printf("[PARSER][EAT-AFTER] TOKEN_START: lexer->pos=%d, src[周围]=\"%s\", token_type=%d (%s), value='%s'\n", pos, buf, parser->current_token->type, token_type_to_string(parser->current_token->type), parser->current_token->value ? parser->current_token->value : "NULL");
+        }
     }
     else
     {
-        printf("Syntax error: Expected token type %d (%s), but got token type %d (%s)\n",
+        printf("[PARSER] 语法错误：期望 token type %d (%s)，但实际 token type %d (%s)\n",
                type, token_type_to_string(type), parser->current_token->type, token_type_to_string(parser->current_token->type));
-        exit(1);
+        fprintf(stderr, "[PARSER ERROR] Fatal error encountered, returning NULL而不中断主流程\n");
+        return;
     }
 }
+
+// 前置声明
+ASTNode *parse_c_block_statement(Parser *parser);
+
+// =====================
+// 解析单条 HerCode 语句
+// =====================
 ASTNode *parse_statement(Parser *parser)
 {
-    // 跳过无关token
-    while (parser->current_token->type == TOKEN_DEDENT ||
-           parser->current_token->type == TOKEN_NEWLINE ||
-           parser->current_token->type == TOKEN_INDENT)
-    {
+    // 调用者（例如 parse_function_definition 或 parse_program）已跳过了前导的换行符（解析器定位在潜在语句的开始位置）
+    // parser->current_indent 为这个语句块预期的缩进级别
+    // *** 实际的当前缩进在 parser->lexer->indent_stack[parser->lexer->indent_top] 中
 
-        // 更新缩进状态
-        if (parser->current_token->type == TOKEN_INDENT)
-        {
-            parser->current_indent++;
-        }
-        else if (parser->current_token->type == TOKEN_DEDENT)
-        {
-            parser->current_indent--;
-        }
+    printf("[PARSER][parse_statement] token=%d (%s), expected_indent=%d, lexer_indent=%d\n",
+           parser->current_token->type, token_type_to_string(parser->current_token->type),
+           parser->current_indent, parser->lexer->indent_stack[parser->lexer->indent_top]);
 
-        eat(parser, parser->current_token->type);
-    }
+    // 验证当前符号是否处于当前块的预期缩进级别
+    // 这个检查可能过于简单，具体取决于词法分析器如何处理制表符/空格以及混合缩进
+    // 目前假设词法分析器提供一致的 indent_level
+    // if (parser->lexer->indent_stack[parser->lexer->indent_top] != parser->current_indent) {
+    //     fprintf(stderr, "语法错误：语句位于意外的缩进级别。预期缩进 %d，实际缩进 %d，符号为 %s\n",
+    //             parser->current_indent, parser->lexer->indent_stack[parser->lexer->indent_top],
+    //             token_type_to_string(parser->current_token->type));
+    //     // 不要消耗符号，让调用者处理这个结构性错误
+    //     return NULL;
+    // }
 
-    // 打印调试信息
-    printf("[PARSER] parse_statement token: %s (%d)\n",
-           token_type_to_string(parser->current_token->type),
-           parser->current_token->type);
-
-    // 识别不同语句类型
     switch (parser->current_token->type)
     {
     case TOKEN_SAY:
         return parse_say_statement(parser);
-    case TOKEN_FUNCTION:
-        return parse_function_definition(parser);
-    case TOKEN_IDENTIFIER:
+    case TOKEN_C_BLOCK:
+        return parse_c_block_statement(parser);
+    case TOKEN_IDENTIFIER: // 可能是一个函数调用语句
         return parse_function_call(parser);
-    }
+    // FUNCTION、START、END、DEDENT、EOF、INDENT、NEWLINE等结构性符号
+    // 应该在调用 parse_statement 之前由块解析逻辑（例如在 parse_function_definition 或 parse_program 中）处理
+    default:
+        fprintf(stderr, "[PARSER][parse_statement] 语法错误：在期望语句的地方遇到意外的标记 %s (type %d)。\n",
+               token_type_to_string(parser->current_token->type), parser->current_token->type);
 
-    // 未知语句类型
-    fprintf(stderr, "Syntax error: Unknown statement. Got token %d (%s)\n",
-            parser->current_token->type,
-            token_type_to_string(parser->current_token->type));
-    exit(1);
+        // 保留原始行为，对于未知的语句起始，消耗掉当前符号并返回 NULL
+        eat(parser, parser->current_token->type);
+        return NULL;
+    }
+}
+
+// 解析__c__ { ... } 语法块
+ASTNode *parse_c_block_statement(Parser *parser)
+{
+    // 直接处理 TOKEN_C_BLOCK，无需检查 '{'
+    ASTNode *node = create_c_block_node(parser->current_token->value);
+    eat(parser, TOKEN_C_BLOCK);
+    return node;
 }
 
 ASTNode *parse_say_statement(Parser *parser)
 {
-    eat(parser, TOKEN_SAY); // 消耗'say' token
+    eat(parser, TOKEN_SAY); // 消耗 'say' token
 
-    // 确保下一个token是字符串
+    // 确保下一个 token 是字符串
     if (parser->current_token->type != TOKEN_STRING)
     {
-        fprintf(stderr, "Syntax error: Expected string after 'say'\n");
-        exit(1);
+        fprintf(stderr, "[PARSER] 语法错误：'say' 后面应该是字符串\n");
+        fprintf(stderr, "[PARSER ERROR] 遇到致命错误，返回 NULL 而不中断主流程\n");
+        printf("[PARSER][parse_program] 返回了 NULL 在 %s:%d (未找到 start: 块)\n", __FILE__, __LINE__);
+        return NULL;
     }
 
-    char *str_value = parser->current_token->value ? strdup(parser->current_token->value) : strdup("");
+    char *str_value = parser->current_token->value ? _strdup(parser->current_token->value) : _strdup("");
 
-    eat(parser, TOKEN_STRING); // 消耗字符串token
+    eat(parser, TOKEN_STRING); // 消耗掉字符串 token
 
     return create_say_node(str_value);
 }
 
 ASTNode *parse_function_definition(Parser *parser)
 {
-    printf("[PARSER] Parsing function definition\n");
+    printf("[PARSER] 解析函数定义\n");
 
-    // 消耗 function 关键字
     eat(parser, TOKEN_FUNCTION);
 
-    // 检查函数名
     if (parser->current_token->type != TOKEN_IDENTIFIER)
     {
-        fprintf(stderr, "Syntax error: Expected function name after 'function'. Got token %d (%s)\n",
-                parser->current_token->type,
-                token_type_to_string(parser->current_token->type));
-        exit(1);
+        fprintf(stderr, "[PARSER] 语法错误：'function' 后面应该是函数名。实际上是 token %d (%s)\n",
+                parser->current_token->type, token_type_to_string(parser->current_token->type));
+        return NULL;
     }
-    char *func_name = strdup(parser->current_token->value);
+    char *func_name = _strdup(parser->current_token->value);
+    if (!func_name) { // 检查 strdup 的结果
+        fprintf(stderr, "[PARSER] 内存分配失败，无法存储函数名\n");
+        return NULL;
+    }
     eat(parser, TOKEN_IDENTIFIER);
-    printf("  Function name: '%s'\n", func_name);
+    printf("[PARSER] 函数名：'%s'\n", func_name);
 
-    // 检查冒号
     if (parser->current_token->type != TOKEN_COLON)
     {
-        fprintf(stderr, "Syntax error: Expected colon after function name. Got token %d (%s)\n",
-                parser->current_token->type,
-                token_type_to_string(parser->current_token->type));
-        exit(1);
+        fprintf(stderr, "[PARSER] 语法错误：函数名 '%s' 后面应该是冒号。实际上是 token %d (%s)\n",
+                func_name, parser->current_token->type, token_type_to_string(parser->current_token->type));
+        free(func_name); // 释放分配的名称内存
+        return NULL;
     }
     eat(parser, TOKEN_COLON);
 
-    // 处理函数定义后的可能空白
-    int first_token = 1;
-
-    // 解析函数体
-    ASTNode **body = NULL;
-    int body_capacity = 8; // 初始容量
-    int body_count = 0;
-    parser->current_indent = -1; // 标记函数体缩进级别未设置
-
-    // 初始化body数组
-    body = malloc(body_capacity * sizeof(ASTNode *));
-    if (!body)
+    // 跳过任何紧跟冒号后的换行符
+    while (parser->current_token->type == TOKEN_NEWLINE)
     {
-        fprintf(stderr, "Memory allocation failed for function body\n");
-        exit(1);
+        eat(parser, TOKEN_NEWLINE);
     }
 
-    // 直到遇到end或DEDENT
-    while (1)
+    int function_body_indent_level = parser->current_indent; // 缩进级别在函数体开始之前
+
+    // 期望函数体进行缩进，除非紧跟着的是下一个块
+    if (parser->current_token->type == TOKEN_INDENT)
     {
-        // 处理空白token
-        while (parser->current_token->type == TOKEN_NEWLINE ||
-               parser->current_token->type == TOKEN_INDENT ||
-               parser->current_token->type == TOKEN_DEDENT)
-        {
-            // 第一次遇到缩进，设置当前缩进级别
-            if (parser->current_token->type == TOKEN_INDENT &&
-                parser->current_indent == -1)
-            {
-                parser->current_indent = parser->lexer->indent_stack[parser->lexer->indent_top];
-                printf("  Function body indent set to: %d\n", parser->current_indent);
-            }
-
-            eat(parser, parser->current_token->type);
-        }
-
-        // 检查结束条件
-        if (parser->current_token->type == TOKEN_END)
-        {
-            break;
-        }
-
-        // 如果遇到DEDENT，检查是否已经返回到函数定义层级
-        if (parser->current_token->type == TOKEN_DEDENT &&
-            parser->current_indent != -1 &&
-            parser->lexer->indent_stack[parser->lexer->indent_top] < parser->current_indent)
-        {
-            printf("  Exiting function body at indent: %d (current: %d)\n",
-                   parser->current_indent, parser->lexer->indent_stack[parser->lexer->indent_top]);
-            break;
-        }
-
-        // 遇到函数体中的语句
-        printf("  Parsing function body statement (%s)\n", token_type_to_string(parser->current_token->type));
-
-        // 检查并扩展数组容量
-        if (body_count >= body_capacity)
-        {
-            body_capacity *= 2;
-            ASTNode **new_body = realloc(body, body_capacity * sizeof(ASTNode *));
-            if (!new_body)
-            {
-                fprintf(stderr, "Memory reallocation failed for function body\n");
-                exit(1);
-            }
-            body = new_body;
-        }
-
-        // 解析语句并存储
-        ASTNode *stmt = parse_statement(parser);
-        body[body_count++] = stmt;
-    }
-
-    // 消耗end关键字
-    if (parser->current_token->type == TOKEN_END)
-    {
-        eat(parser, TOKEN_END);
+        eat(parser, TOKEN_INDENT);
+        function_body_indent_level = parser->lexer->indent_stack[parser->lexer->indent_top];
+        parser->current_indent = function_body_indent_level; // 设置函数体的当前预期缩进
+        printf("[PARSER] 函数 '%s' 体的缩进级别设为：%d\n", func_name, function_body_indent_level);
     }
     else
     {
-        fprintf(stderr, "Syntax error: Expected 'end' to close function definition. Got %d (%s)\n",
-                parser->current_token->type,
-                token_type_to_string(parser->current_token->type));
-        exit(1);
+        // 未找到 INDENT（可能是一个空函数或语法错误）
+        // *** 如果是 EOF, END, DEDENT, FUNCTION, 或 START，视为空函数
+        if (parser->current_token->type == TOKEN_EOF || parser->current_token->type == TOKEN_END ||
+            parser->current_token->type == TOKEN_DEDENT || parser->current_token->type == TOKEN_FUNCTION ||
+            parser->current_token->type == TOKEN_START)
+        {
+            printf("[PARSER] 函数 '%s' 为空（无缩进，后面跟着 %s）\n", func_name, token_type_to_string(parser->current_token->type));
+            ASTNode *func_node = create_function_def_node(func_name, NULL, 0);
+            // func_name 和 body_statements 归属都转到 func_node
+            return func_node;
+        }
+        else
+        {
+            fprintf(stderr, "[PARSER] 语法错误：函数 '%s' 的函数体应该缩进或有效结束。实际上是 %s\n",
+                    func_name, token_type_to_string(parser->current_token->type));
+            free(func_name);
+            return NULL;
+        }
     }
 
-    // 重置缩进级别
-    parser->current_indent = 0;
-    printf("Successfully parsed function '%s' with %d statements\n", func_name, body_count);
-
-    ASTNode *result = create_function_def_node(func_name, body, body_count);
-    if (!result)
+    ASTNode **body_statements = NULL;
+    int body_capacity = 8;
+    int body_statement_count = 0;
+    body_statements = malloc(body_capacity * sizeof(ASTNode *));
+    if (!body_statements)
     {
-        free(body);
+        fprintf(stderr, "[PARSER] 内存分配失败，无法存储函数体语句 '%s'\n", func_name);
+        free(func_name);
         return NULL;
     }
-    return result;
+
+    while (1)
+    {
+        // 跳过函数体内的前导换行符
+        while (parser->current_token->type == TOKEN_NEWLINE)
+        {
+            eat(parser, TOKEN_NEWLINE);
+        }
+
+        TokenType current_token_type = parser->current_token->type;
+
+        // 检查函数体结束的条件
+        if (current_token_type == TOKEN_EOF ||     // 结束
+            current_token_type == TOKEN_FUNCTION || // 新函数的开始
+            current_token_type == TOKEN_START)      // 主 'start:' 块的开始
+        {
+            printf("[PARSER] 函数 '%s' 体隐式结束，由于 %s (token 未被消耗)\n", func_name, token_type_to_string(current_token_type));
+            break; // 不消耗这些符号，交由父级解析器 (parse_program) 处理
+        }
+
+        if (current_token_type == TOKEN_END) // 函数的显式 end 关键字
+        {
+            printf("[PARSER] 函数 '%s' 体显式结束 (消耗 END token)\n", func_name);
+            eat(parser, TOKEN_END);
+            break;
+        }
+
+        // 检查缩进是否减少（函数体结束）
+        if (current_token_type == TOKEN_DEDENT)
+        {
+            // 词法分析器的当前 indent_stack 顶部为 DEDENT 处理后的缩进级别
+            if (parser->lexer->indent_stack[parser->lexer->indent_top] < function_body_indent_level)
+            {
+                printf("[PARSER] 函数 '%s' 体隐式结束，由于 DEDENT (body_indent: %d, new_lexer_indent: %d)。消耗 DEDENT。\n",
+                       func_name, function_body_indent_level, parser->lexer->indent_stack[parser->lexer->indent_top]);
+                eat(parser, TOKEN_DEDENT);
+                parser->current_indent = parser->lexer->indent_stack[parser->lexer->indent_top]; // 更新解析器对当前缩进的记录
+                break;
+            }
+            else
+            {
+                // 这个 DEDENT 不会更改函数体的已建立的缩进级别
+                // 如果在函数体之后没有 DEDENT（直接是 EOF 或 END），并且缩进级别未恢复到函数前的级别（错误）
+                // 消耗掉并让语句解析逻辑处理或报错
+                printf("[PARSER] 函数 '%s' 体内遇到 DEDENT，但新的缩进级别 (%d) 不小于函数体缩进级别 (%d)。消耗 DEDENT。\n",
+                       func_name, parser->lexer->indent_stack[parser->lexer->indent_top], function_body_indent_level);
+                eat(parser, TOKEN_DEDENT);
+                parser->current_indent = parser->lexer->indent_stack[parser->lexer->indent_top];
+                // 在这个新的（但仍大于等于函数体缩进级别）缩进处继续解析语句
+            }
+        }
+        
+        // 如果当前符号的有效缩进（来自词法分析器）小于 function_body_indent_level，则表示隐式结束
+        // 针对那些本身不是 DEDENT 符号但缩进较浅的行
+        if (parser->lexer->indent_stack[parser->lexer->indent_top] < function_body_indent_level) {
+             printf("[PARSER] 函数 '%s' 体隐式结束，由于缩进级别减少 (body_indent: %d, current_line_indent: %d) 为 token %s (未被消耗)\n",
+                   func_name, function_body_indent_level, parser->lexer->indent_stack[parser->lexer->indent_top], token_type_to_string(current_token_type));
+            break; // 不要消耗这个符号，交由父级处理
+        }
+
+        // 如果发生错误，导致错误的符号可能已经被 parse_statement 或 eat 消耗掉了
+        if (body_statement_count >= body_capacity)
+        {
+            body_capacity *= 2;
+            ASTNode **new_body = realloc(body_statements, body_capacity * sizeof(ASTNode *));
+            if (!new_body)
+            {
+                fprintf(stderr, "[PARSER] 内存重新分配失败，无法存储函数体语句 '%s'\n", func_name);
+                for (int i = 0; i < body_statement_count; i++) free_node(body_statements[i]);
+                free(body_statements);
+                free(func_name);
+                return NULL;
+            }
+            body_statements = new_body;
+        }
+
+        // 对于直接在函数体中的语句，parser->current_indent 是函数体的缩进级别
+        parser->current_indent = function_body_indent_level; 
+        ASTNode *stmt = parse_statement(parser);
+        if (!stmt)
+        {
+            fprintf(stderr, "[PARSER] 错误解析函数 '%s' 中的语句 (当前 token: %s)。终止函数解析。\n",
+                    func_name, token_type_to_string(parser->current_token->type));
+            for (int i = 0; i < body_statement_count; i++) free_node(body_statements[i]);
+            free(body_statements);
+            free(func_name);
+            return NULL;
+        }
+        body_statements[body_statement_count++] = stmt;
+    }
+
+    // 循环结束后，parser->current_indent 为此函数定义之后活动的缩进级别
+    // 如果循环因 DEDENT 停止（已经被更新）。否则，这将是词法分析器当前栈顶的值
+    parser->current_indent = parser->lexer->indent_stack[parser->lexer->indent_top];
+    printf("[PARSER] 函数 '%s' 解析完成。最终解析器缩进级别：%d\n", func_name, parser->current_indent);
+
+    ASTNode *func_node = create_function_def_node(func_name, body_statements, body_statement_count);
+    if (!func_node) { 
+        fprintf(stderr, "[PARSER] 创建函数节点 '%s' 失败\n", func_name);
+        for (int i = 0; i < body_statement_count; i++) free_node(body_statements[i]);
+        free(body_statements);
+        free(func_name);
+        return NULL;
+    }
+
+    printf("[PARSER] 成功解析函数 '%s'，包含 %d 语句\n", func_name, body_statement_count);
+    return func_node;
 }
 
 ASTNode *parse_function_call(Parser *parser)
 {
     if (parser->current_token->type != TOKEN_IDENTIFIER)
     {
-        fprintf(stderr, "Syntax error: Expected function name\n");
-        exit(1);
+        fprintf(stderr, "[PARSER] 语法错误：期望函数名\n");
+        fprintf(stderr, "[PARSER ERROR] 遇到致命错误，返回 NULL 而不中断主流程\n");
+        printf("[PARSER][parse_program] 返回 NULL at %s:%d (未找到 start: 块)\n", __FILE__, __LINE__);
+        return NULL;
     }
 
-    char *func_name = strdup(parser->current_token->value);
+    char *func_name = _strdup(parser->current_token->value);
     eat(parser, TOKEN_IDENTIFIER);
 
     return create_function_call_node(func_name);
@@ -287,10 +392,17 @@ ASTNode *parse_block(Parser *parser, int *count)
 
     while (1)
     {
-        // 处理行内Token
+        // 终极死循环保护：块体内遇到 TOKEN_START 直接 eat 并 continue
+        if (parser->current_token->type == TOKEN_START) {
+            printf("[parse_block] 主循环头遇到 TOKEN_START，主动 eat 并 continue\n");
+            eat(parser, TOKEN_START);
+            continue;
+        }
+        // 处理行内 Token
         while (parser->current_token->type == TOKEN_NEWLINE ||
                parser->current_token->type == TOKEN_INDENT)
-        { // 添加对缩进Token的处理
+        {
+            // 添加对缩进 Token 的处理
             eat(parser, parser->current_token->type);
         }
 
@@ -307,14 +419,26 @@ ASTNode *parse_block(Parser *parser, int *count)
             ASTNode **new_nodes = realloc(nodes, nodes_capacity * sizeof(ASTNode *));
             if (!new_nodes)
             {
-                fprintf(stderr, "Memory reallocation failed for block nodes\n");
-                exit(1);
+                fprintf(stderr, "[PARSER] 内存重新分配失败，无法存储块节点\n");
+                fprintf(stderr, "[PARSER ERROR] 遇到致命错误，返回 NULL 而不中断主流程\n");
+                printf("[PARSER][parse_program] 返回 NULL 在 %s:%d (未找到 start: 块)\n", __FILE__, __LINE__);
+                return NULL;
             }
             nodes = new_nodes;
         }
-        nodes[*count] = parse_statement(parser);
+        ASTNode *stmt = parse_statement(parser);
+        if (!stmt) {
+            printf("[PARSER][parse_block] parse_statement 返回 NULL，强制 eat 当前 token type=%d (%s) 并 continue\n",
+                   parser->current_token->type, token_type_to_string(parser->current_token->type));
+            eat(parser, parser->current_token->type);
+            continue;
+        }
+        nodes[*count] = stmt;
         (*count)++;
+
+
     }
+    // 假设block节点类型为STMT_SAY
     ASTNode *block = create_block_node(nodes, *count);
     if (!block)
     {
@@ -323,167 +447,134 @@ ASTNode *parse_block(Parser *parser, int *count)
             free_node(nodes[i]);
         }
         free(nodes);
+        printf("[PARSER][parse_program] 返回 NULL 在 %s:%d (未找到start:块)\n", __FILE__, __LINE__);
         return NULL;
     }
     free(nodes);
     return block;
 }
 
+// =====================
+// 解析整个 HerCode 程序
+// =====================
 ASTNode **parse_program(Parser *parser, int *count)
 {
+    printf("[DEBUG] 进入 parse_program\n");
     *count = 0;
     ASTNode **nodes = NULL;
     int nodes_capacity = 0;
 
-    // 允许函数定义出现在程序开头
-    while (parser->current_token->type != TOKEN_EOF)
+    // 跳过头部的无关符号
+    while (parser->current_token->type == TOKEN_NEWLINE ||
+           parser->current_token->type == TOKEN_INDENT ||
+           parser->current_token->type == TOKEN_DEDENT)
     {
-        // 跳过缩进和换行符
-        while (parser->current_token->type == TOKEN_NEWLINE ||
-               parser->current_token->type == TOKEN_INDENT ||
-               parser->current_token->type == TOKEN_DEDENT)
+        eat(parser, parser->current_token->type);
+    }
+
+    // 允许全局函数定义
+    while (parser->current_token->type == TOKEN_FUNCTION)
+    {
+        ASTNode *func = parse_function_definition(parser);
+        if (func)
         {
+            if (*count >= nodes_capacity)
+            {
+                nodes_capacity = nodes_capacity ? nodes_capacity * 2 : 8;
+                nodes = realloc(nodes, nodes_capacity * sizeof(ASTNode *));
+            }
+            nodes[(*count)++] = func;
+        }
+        // 函数定义之后，跳过所有尾随的 END 符号和换行符
+        // 然后再查找下一个 FUNCTION 符号或 START 符号
+        while (parser->current_token->type == TOKEN_NEWLINE ||
+               parser->current_token->type == TOKEN_END)
+        {
+            printf("[PARSER][parse_program] 跳过 top-level %s 在函数定义后\n",
+                   token_type_to_string(parser->current_token->type));
             eat(parser, parser->current_token->type);
         }
-
-        // 检查是否达到文件末尾
-        if (parser->current_token->type == TOKEN_EOF)
-        {
-            break;
-        }
-
-        // 检查是否遇到start关键字
-        if (parser->current_token->type == TOKEN_START)
-        {
-            break;
-        }
-
-        // 解析函数定义
-        if (*count >= nodes_capacity)
-        {
-            nodes_capacity = nodes_capacity ? nodes_capacity * 2 : 8;
-            ASTNode **new_nodes = realloc(nodes, nodes_capacity * sizeof(ASTNode *));
-            if (!new_nodes)
-            {
-                fprintf(stderr, "Memory reallocation failed for program nodes\n");
-                exit(1);
-            }
-            nodes = new_nodes;
-        }
-
-        // 解析其他语句（包括函数定义）
-        ASTNode *node = parse_statement(parser);
-        if (node)
-        {
-            nodes[(*count)++] = node;
-        }
     }
 
-    // 程序必须以start开始
+    // 在所有函数定义解析完毕后（或没有函数定义）
+    // 在期望的 START 符号之前，跳过所有残留的换行符或 END 符号
+    while (parser->current_token->type == TOKEN_NEWLINE ||
+           parser->current_token->type == TOKEN_END)
+    {
+        printf("[PARSER][parse_program] 跳过 top-level %s 在 START block 检查前\n",
+               token_type_to_string(parser->current_token->type));
+        eat(parser, parser->current_token->type);
+    }
+
+    // 只允许一个 start:
     if (parser->current_token->type != TOKEN_START)
     {
-        fprintf(stderr, "Syntax error: Program must contain 'start:' block\n");
-        exit(1);
+        fprintf(stderr, "[PARSER] 语法错误：程序必须包含 'start:' 块\n");
+        return NULL;
     }
-    eat(parser, TOKEN_START); // 消耗start token
-
-    // 处理可选的换行符
+    eat(parser, TOKEN_START);
     while (parser->current_token->type == TOKEN_NEWLINE)
-    {
         eat(parser, TOKEN_NEWLINE);
-    }
-
-    // 必须有缩进
     if (parser->current_token->type != TOKEN_INDENT)
     {
-        fprintf(stderr, "Syntax error: Expected indentation after 'start:'\n");
-        exit(1);
+        fprintf(stderr, "[PARSER] 语法错误：期望 'start:' 后面有缩进\n");
+        return NULL;
     }
     eat(parser, TOKEN_INDENT);
     parser->current_indent++;
 
-    // 解析程序主体
-    while (parser->current_token->type != TOKEN_EOF)
+    // 主程序块
+    while (parser->current_token->type != TOKEN_DEDENT &&
+           parser->current_token->type != TOKEN_END &&
+           parser->current_token->type != TOKEN_EOF)
     {
-        // 处理缩出（从当前缩进级别退出）
-        if (parser->current_token->type == TOKEN_DEDENT)
+        // 跳过冗余的 start: ，防止无限循环
+        if (parser->current_token->type == TOKEN_START)
         {
-            eat(parser, TOKEN_DEDENT);
-            parser->current_indent--;
-
-            // 当缩进级别回到0时，准备退出程序块
-            if (parser->current_indent == 0)
+            printf("[PARSER][parse_program] 主循环遇到多余TOKEN_START，主动eat并continue\n");
+            eat(parser, TOKEN_START);
+            continue;
+        }
+        ASTNode *stmt = parse_statement(parser);
+        if (stmt)
+        {
+            if (*count >= nodes_capacity)
             {
-                break;
+                nodes_capacity = nodes_capacity ? nodes_capacity * 2 : 8;
+                nodes = realloc(nodes, nodes_capacity * sizeof(ASTNode *));
             }
-            continue;
+            nodes[(*count)++] = stmt;
         }
-
-        // 跳过换行符
-        if (parser->current_token->type == TOKEN_NEWLINE)
-        {
-            eat(parser, TOKEN_NEWLINE);
-            continue;
-        }
-
-        // 处理end关键字（提前退出）
-        if (parser->current_token->type == TOKEN_END)
-        {
-            break;
-        }
-
-        // 确保不超过最大语句数
-        if (*count >= nodes_capacity)
-        {
-            nodes_capacity = nodes_capacity ? nodes_capacity * 2 : 8;
-            nodes = realloc(nodes, nodes_capacity * sizeof(ASTNode *));
-        }
-
-        // 解析语句
-        nodes[(*count)++] = parse_statement(parser);
+        // parse_statement 返回 NULL 说明遇到无效符号，已被自动消耗，无需再次消耗
     }
 
-    // 在缩出循环后，跳过所有换行符和DEDENT
+    // 退出主程序块
+    if (parser->current_token->type == TOKEN_DEDENT)
+    {
+        eat(parser, TOKEN_DEDENT);
+        parser->current_indent--;
+    }
+
+    // 跳过冗余的NEWLINE/DEDENT
     while (parser->current_token->type == TOKEN_NEWLINE ||
            parser->current_token->type == TOKEN_DEDENT)
     {
         eat(parser, parser->current_token->type);
     }
 
-    // 处理end关键字
-    if (parser->current_token->type == TOKEN_EOF)
-    {
-        fprintf(stderr, "Syntax error: Program must end with 'end'\n");
-        exit(1);
-    }
+    // 处理end符号
+    if (parser->current_token->type == TOKEN_END)
+        eat(parser, TOKEN_END);
 
-    if (parser->current_token->type != TOKEN_END)
-    {
-        fprintf(stderr, "Syntax error: Expected 'end' at end of program. Got token type %d (%s)\n",
-                parser->current_token->type,
-                token_type_to_string(parser->current_token->type));
-        exit(1);
-    }
-    eat(parser, TOKEN_END);
-
-    // 确保缩进级别回到0
+    // 结尾缩进检查
     if (parser->current_indent != 0)
     {
-        // 处理剩余的缩出标记
-        while (parser->current_token->type == TOKEN_DEDENT)
-        {
-            eat(parser, TOKEN_DEDENT);
-            parser->current_indent--;
-        }
-
-        // 如果还有剩余的缩进级别
-        if (parser->current_indent != 0)
-        {
-            fprintf(stderr, "Syntax error: Missing dedent at end of program (indent level=%d)\n",
-                    parser->current_indent);
-            exit(1);
-        }
+        fprintf(stderr, "[PARSER] 语法错误：程序结尾缩进级别不正确 (indent level=%d)\n", parser->current_indent);
     }
 
+    printf("[PARSER][RETURN] node_count=%d\n", *count);
+    for (int i = 0; i < *count; i++) {
+        printf("[PARSER][RETURN] 节点[%d] 类型=%d\n", i, nodes[i] ? nodes[i]->type : -1);
+    }
     return nodes;
 }

--- a/test/her.hercode
+++ b/test/her.hercode
@@ -1,0 +1,8 @@
+
+function say_hello:
+	say "Hello! Her World" #注释
+	say "编程很美，也属于你" #注释2
+end
+start:
+	say_hello
+end

--- a/test/inline.hercode
+++ b/test/inline.hercode
@@ -1,0 +1,47 @@
+# inline.hercode
+
+function inline:
+    say "HerCode调用C代码："
+    __c__ {
+        time_t rawtime;
+        struct tm *info;
+        #define BST (+1)
+        #define CCT (+8)
+        time(&rawtime);
+        /* 获取 GMT 时间 */
+        info = gmtime(&rawtime );
+
+        printf("\t当前的世界时钟：\n");
+        printf("\t中国时间 %2d:%02d\n", (info->tm_hour+CCT)%24, info->tm_min);
+        printf("\t伦敦时间 %2d:%02d\n", (info->tm_hour+BST)%24, info->tm_min);
+    }
+    say "inline函数结束"
+
+function add:
+    say "HerCode准备执行C加法"
+    __c__ {
+        int x = 7, y = 8;
+        printf("\tx + y = %d\n", x + y);
+    }
+    say "add函数结束"
+
+function main:
+    say "HerCode进入main"
+
+    __c__ {
+        // 可以直接写C代码
+        printf("\n");
+        printf("Hello! Her World\n");
+        printf("编程很美，也属于你\n");
+    }
+
+    say " "
+    inline
+    add
+    say " "
+    
+    say "main函数结束"
+
+start:
+    main
+end

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,28 @@
+add_rules("mode.debug", "mode.release")
+add_cxflags("/WX-", {force = true}) -- 关闭警告视为错误
+add_cxflags("/wd4090", {force = true}) -- 忽略C4090警告
+
+set_languages("c11")
+
+-- 指定头文件目录
+add_includedirs("include")
+
+-- 定义目标可执行文件
+target("hercode_compiler")
+    set_kind("binary")
+    add_files("src/*.c")
+    add_includedirs("include")
+
+    -- Windows下特殊设置
+    if is_plat("windows") then
+        add_cxflags("/W4", "/WX", "/utf-8")
+        add_defines("_CRT_SECURE_NO_WARNINGS")
+    else
+        add_cxflags("-Wall", "-Werror", "-Wstrict-prototypes", "-Wmissing-prototypes", "-O2", "-Os")
+    end
+
+    -- 构建后自动复制到test目录
+    after_build(function (target)
+        os.mkdir("test")
+        os.cp(target:targetfile(), path.join("test", path.filename(target:targetfile())))
+    end)


### PR DESCRIPTION
**新增--out、-r参数**
- 输出为my_program.exe，并移除临时文件。
- ./hercode_compiler.exe her.hercode --out=my_program.exe -r

**解释器现支持：**
```hercode
# inline.hercode

function inline:
    say "HerCode调用C代码："
    __c__ {
        time_t rawtime;
        struct tm *info;
        #define BST (+1)
        #define CCT (+8)
        time(&rawtime);
        /* 获取 GMT 时间 */
        info = gmtime(&rawtime );

        printf("\t当前的世界时钟：\n");
        printf("\t中国时间 %2d:%02d\n", (info->tm_hour+CCT)%24, info->tm_min);
        printf("\t伦敦时间 %2d:%02d\n", (info->tm_hour+BST)%24, info->tm_min);
    }
    say "inline函数结束"

function add:
    say "HerCode准备执行C加法"
    __c__ {
        int x = 7, y = 8;
        printf("\tx + y = %d\n", x + y);
    }
    say "add函数结束"

function main:
    say "HerCode进入main"

    __c__ {
        // 可以直接写C代码
        printf("\n");
        printf("Hello! Her World\n");
        printf("编程很美，也属于你\n");
    }

    say " "
    inline
    add
    say " "
    
    say "main函数结束"
	# 不会报错，因为现已支持函数定义隐式结束。

start:
    main
end
```

**修复Issues：** #4 